### PR TITLE
Update applyFacts default case

### DIFF
--- a/src/Elm/Kernel/VirtualDom.js
+++ b/src/Elm/Kernel/VirtualDom.js
@@ -493,7 +493,7 @@ function _VirtualDom_applyFacts(domNode, eventNode, facts)
 		key === 'a__1_ATTR_NS'
 			? _VirtualDom_applyAttrsNS(domNode, value)
 			:
-		(key !== 'value' || key !== 'checked' || domNode[key] !== value) && (domNode[key] = value);
+		((domNode[key] === '' && domNode[key] !== value) || (key !== 'value' && key !== 'checked' && domNode[key] !== value)) && (domNode[key] = value);
 	}
 }
 


### PR DESCRIPTION
the previous logic `(key !== 'value' || key !== 'checked' || domNode[key] !== value)` would always resolve to `true`.

Here are some test cases trying to better explain the reasoning behind the proposed solution:

```
function applyFactsDefaultCase(key, domNodeValue, value) {
  var domNode = {};
  domNode[key] = domNodeValue;

  // ORIGINAL
  // return (key !== 'value' || key !== 'checked' || domNode[key] !== value);

  // PROPOSED SOLUTION
  // if(domNode[key] === '') {
  //   return domNode[key] !== value;
  // } else if(key === 'value' || key === 'checked') {
  //   return false;
  // } else {
  //   return domNode[key] !== value;
  // }
  return (domNode[key] === '' && domNode[key] !== value) || (key !== 'value' && key !== 'checked' && domNode[key] !== value);
}

// Test cases
console.log([
  // key === 'value', same value, no update to the DOM
  applyFactsDefaultCase('value', 'foo', 'foo') === false,
  // key === 'value', updated value, no update to the DOM
  applyFactsDefaultCase('value', 'foo', 'foo2') === false,
  // key === 'value', initial value, updates the DOM
  applyFactsDefaultCase('value', '', 'foo') === true,
  // key === 'value', initial empty value, no update to the DOM
  applyFactsDefaultCase('value', '', '') === false,

  // key === 'checked', same value, no update to the DOM
  applyFactsDefaultCase('checked', 'foo', 'foo') === false,
  // key === 'checked', updated value, no update to the DOM
  applyFactsDefaultCase('checked', 'foo', 'foo2') === false,
  // key === 'checked', initial value, updates the DOM
  applyFactsDefaultCase('checked', '', 'foo') === true,
  // key === 'checked', initial empty value, no update to the DOM
  applyFactsDefaultCase('checked', '', '') === false,

  // key !== 'value' && key !== 'checked', same value, no update to the DOM
  applyFactsDefaultCase('bar', 'foo', 'foo') === false,
  // key !== 'value' && key !== 'checked', updated value, updates the DOM
  applyFactsDefaultCase('bar', 'foo', 'foo2') === true,
  // key !== 'value' && key !== 'checked', initial value, updates the DOM
  applyFactsDefaultCase('bar', '', 'foo') === true,
  // key !== 'value' && key !== 'checked', initial empty value, no update to the DOM
  applyFactsDefaultCase('bar', '', '') === false
]);
```

fixes elm/virtual-dom/issues/134